### PR TITLE
fix: Crash on iOS/Android from eager cross-platform HybridObject imports

### DIFF
--- a/android/src/main/java/com/margelo/nitro/TurboScryptAndroid/HybridPoopy.kt
+++ b/android/src/main/java/com/margelo/nitro/TurboScryptAndroid/HybridPoopy.kt
@@ -48,6 +48,6 @@ class HybridPoopy(val context: ThemedReactContext) : HybridPoopySpec() {
         keyBuffer.rewind()
 
         // ByteBuffer -> ArrayBuffer
-        return ArrayBuffer(keyBuffer)
+        return ArrayBuffer.wrap(keyBuffer)
     }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": "*"
+    "react-native-nitro-modules": ">=0.31.6"
   },
   "eslintConfig": {
     "root": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 import { Platform } from 'react-native'
 
-import { CryptoSwift } from './CryptoSwift'
-import { BouncyCastle } from './BouncyCastle'
-
 export const Scrypt = {
   scrypt: (
     password: ArrayBuffer,
@@ -13,8 +10,8 @@ export const Scrypt = {
     size: number
   ): ArrayBuffer => {
     const openNative = Platform.select({
-      ios: () => CryptoSwift.scrypt(password, salt, N, r, p, size),
-      android: () => BouncyCastle.scrypt(password, salt, N, r, p, size),
+      ios: () => require('./CryptoSwift').CryptoSwift.scrypt(password, salt, N, r, p, size),
+      android: () => require('./BouncyCastle').BouncyCastle.scrypt(password, salt, N, r, p, size),
     })
 
     if (!openNative) {


### PR DESCRIPTION
Importing `Scrypt` from `react-native-nitro-scrypt` crashes on iOS with:                                                      
                                                                                                                                
  > Cannot create an instance of HybridObject "Poopy" - It has not yet been registered in the Nitro Modules
  HybridObjectRegistry!

  The top-level `import` statements for both `CryptoSwift` (iOS) and `BouncyCastle` (Android) caused both native HybridObjects
  to be instantiated at module load time, regardless of platform. On iOS the Android-only `Poopy` HybridObject doesn't exist,
  and vice versa on Android with `Scrypt`.

  ### Fix

  Replaced the eager top-level `import` statements with lazy `require()` calls inside the `Platform.select` callbacks. This
  ensures only the current platform's native module is loaded and instantiated.

  **Before:**
  ```ts
  import { CryptoSwift } from './CryptoSwift'
  import { BouncyCastle } from './BouncyCastle'

  // Both HybridObjects created at import time — crashes on the wrong platform

  After:
  // No top-level imports — native modules are required lazily per-platform
  ios: () => require('./CryptoSwift').CryptoSwift.scrypt(...),
  android: () => require('./BouncyCastle').BouncyCastle.scrypt(...),